### PR TITLE
feat: Derive version from git tags via setuptools-scm

### DIFF
--- a/ccmux/__init__.py
+++ b/ccmux/__init__.py
@@ -1,3 +1,8 @@
 """Claude Code Multiplexer - Manage multiple Claude Code sessions."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("ccmux")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"

--- a/ccmux/cli.py
+++ b/ccmux/cli.py
@@ -19,11 +19,13 @@ from ccmux.session_ops import (
     do_session_rename,
     do_session_which,
 )
+from ccmux import __version__
 from ccmux.session_layout import do_debug_sidebar
 from ccmux.display import console
 
 app = cyclopts.App(
     name="ccmux",
+    version=__version__,
     help="Claude Code Multiplexer - Manage multiple Claude Code sessions.",
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccmux"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Claude Code Multiplexer - Manage multiple Claude Code instances"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -49,3 +49,5 @@ include = ["ccmux*"]
 
 [tool.setuptools.package-data]
 "ccmux.ui.sidebar" = ["sidebar.tcss"]
+
+[tool.setuptools_scm]


### PR DESCRIPTION
## Summary
- Replace hardcoded `version = "0.1.0"` with `setuptools-scm` to derive the version from git tags at build time, eliminating version mismatches between `pyproject.toml` and `__init__.py`
- Read version at runtime via `importlib.metadata` (stdlib since Python 3.8) with a fallback for uninstalled dev runs
- Wire up `ccmux --version` flag via cyclopts for free

Closes #2

## Test plan
- [ ] `pip install -e .` succeeds and shows a dev version like `0.1.1.dev2+g9d8a046`
- [ ] `python -c "from ccmux import __version__; print(__version__)"` prints the correct version
- [ ] `ccmux --version` prints the correct version
- [ ] Running without install (unpackaged) falls back to `0.0.0+unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)