### PR TITLE
refactor: Replace sys.exit() with structured exceptions

### DIFF
--- a/ccmux/cli.py
+++ b/ccmux/cli.py
@@ -11,7 +11,7 @@ from rich.prompt import Confirm
 
 from ccmux import __version__
 from ccmux.display import console
-from ccmux.exceptions import SessionExistsError
+from ccmux.exceptions import CcmuxError, NoSessionsFound
 from ccmux.naming import BASH_SESSION, INNER_SESSION, OUTER_SESSION
 from ccmux.session_layout import do_debug_sidebar
 from ccmux.session_ops import (
@@ -60,11 +60,7 @@ def session_new(
     yes: Annotated[bool, Parameter(name=["-y", "--yes"], negative="")] = False,
 ) -> None:
     """Create a new Claude Code session in main repo or as a git worktree."""
-    try:
-        do_session_new(name=name, worktree=worktree, yes=yes)
-    except SessionExistsError as e:
-        console.print(f"[red]Error:[/red] {e}", style="bold")
-        sys.exit(1)
+    do_session_new(name=name, worktree=worktree, yes=yes)
 
 
 @app.command(name="list")
@@ -79,11 +75,7 @@ def session_rename(
     new: Optional[str] = None,
 ) -> None:
     """Rename a ccmux session."""
-    try:
-        do_session_rename(old=old, new=new)
-    except SessionExistsError as e:
-        console.print(f"[red]Error:[/red] {e}", style="bold")
-        sys.exit(1)
+    do_session_rename(old=old, new=new)
 
 
 @app.command(name="attach")
@@ -204,6 +196,16 @@ def main():
 
     try:
         app()
+    except NoSessionsFound as e:
+        console.print(f"[yellow]{e}[/yellow]")
+        if e.hint:
+            console.print(f"  {e.hint}")
+        sys.exit(0)
+    except CcmuxError as e:
+        console.print(f"[red]Error:[/red] {e}", style="bold")
+        if hasattr(e, "hint") and e.hint:
+            console.print(f"  {e.hint}")
+        sys.exit(e.exit_code)
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted by user[/yellow]")
         sys.exit(130)

--- a/ccmux/exceptions.py
+++ b/ccmux/exceptions.py
@@ -1,8 +1,127 @@
-"""Exceptions for the ccmux package."""
+"""Exception classes for ccmux.
+
+Business logic raises these exceptions; the CLI layer catches and presents them.
+No rich markup — plain text messages + structured fields. CLI adds formatting.
+"""
 
 
-class SessionExistsError(Exception):
-    """Raised when a session name is already in use."""
+class CcmuxError(Exception):
+    """Base exception for all ccmux errors."""
+
+    exit_code: int = 1
+
+    def __init__(self, message: str = ""):
+        self.message = message
+        super().__init__(message)
+
+
+class NoSessionsFound(CcmuxError):
+    """No sessions exist (informational, not an error)."""
+
+    exit_code: int = 0
+
+    def __init__(self, hint: str = ""):
+        self.hint = hint
+        super().__init__("No sessions found.")
+
+
+class SessionNotFoundError(CcmuxError):
+    """A named session does not exist."""
+
+    def __init__(self, name: str, hint: str = ""):
+        self.name = name
+        self.hint = hint
+        super().__init__(f"Session '{name}' not found.")
+
+
+class SessionExistsError(CcmuxError):
+    """A session with that name already exists."""
+
     def __init__(self, name: str):
         self.name = name
         super().__init__(f"Session '{name}' already exists.")
+
+
+class NotInGitRepoError(CcmuxError):
+    """The current directory is not inside a git repository."""
+
+    def __init__(self):
+        super().__init__("Not inside a git repository.")
+
+
+class DefaultBranchError(CcmuxError):
+    """Could not detect the default branch."""
+
+    def __init__(self):
+        super().__init__("Could not detect default branch (main/master).")
+
+
+class UserAbortedError(CcmuxError):
+    """The user aborted an operation."""
+
+    def __init__(self, reason: str = ""):
+        self.reason = reason
+        super().__init__(reason or "Aborted.")
+
+
+class TmuxError(CcmuxError):
+    """A tmux operation failed."""
+
+    def __init__(self, operation: str, detail: str = ""):
+        self.operation = operation
+        self.detail = detail
+        msg = f"Tmux {operation} failed."
+        if detail:
+            msg = f"Tmux {operation} failed: {detail}"
+        super().__init__(msg)
+
+
+class WorktreeError(CcmuxError):
+    """A git worktree operation failed."""
+
+    def __init__(self, operation: str, detail: str = ""):
+        self.operation = operation
+        self.detail = detail
+        msg = f"Worktree {operation} failed."
+        if detail:
+            msg = f"Worktree {operation} failed: {detail}"
+        super().__init__(msg)
+
+
+class InvalidArgumentError(CcmuxError):
+    """Invalid or missing CLI arguments."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class NotInCcmuxSessionError(CcmuxError):
+    """Not currently inside a ccmux session."""
+
+    def __init__(self):
+        super().__init__("Not in a ccmux session.")
+
+
+class ActivationError(CcmuxError):
+    """Failed to activate a session."""
+
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(f"Error activating session '{name}'.")
+
+
+class DetachError(CcmuxError):
+    """Failed to detach from a session."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+class AttachError(CcmuxError):
+    """Failed to attach to a session."""
+
+    def __init__(self, reason: str, hint: str = ""):
+        self.reason = reason
+        self.hint = hint
+        super().__init__(reason)

--- a/ccmux/session_ops.py
+++ b/ccmux/session_ops.py
@@ -9,7 +9,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import uuid
 from pathlib import Path
 from typing import Optional
@@ -17,9 +16,23 @@ from typing import Optional
 from rich.prompt import Confirm, Prompt
 
 from ccmux import __version__, state
-from ccmux.exceptions import SessionExistsError
 from ccmux.config import run_post_create
 from ccmux.display import console, display_session_table, show_session_info
+from ccmux.exceptions import (
+    ActivationError,
+    AttachError,
+    DefaultBranchError,
+    DetachError,
+    InvalidArgumentError,
+    NoSessionsFound,
+    NotInCcmuxSessionError,
+    NotInGitRepoError,
+    SessionExistsError,
+    SessionNotFoundError,
+    TmuxError,
+    UserAbortedError,
+    WorktreeError,
+)
 from ccmux.git_ops import (
     create_worktree,
     get_default_branch,
@@ -229,17 +242,15 @@ def migrate_claude_session(old_path: str, new_path: str, session_id: str) -> boo
 # ---------------------------------------------------------------------------
 
 def _validate_repo_context() -> tuple[Path, str]:
-    """Validate git repo and return (repo_root, default_branch). Exits on error."""
+    """Validate git repo and return (repo_root, default_branch). Raises on error."""
     repo_root = get_repo_root()
     if repo_root is None:
-        console.print("[red]Error:[/red] Not inside a git repository.", style="bold")
-        sys.exit(1)
+        raise NotInGitRepoError()
     os.chdir(repo_root)
 
     default_branch = get_default_branch()
     if default_branch is None:
-        console.print("[red]Error:[/red] Could not detect default branch (main/master).", style="bold")
-        sys.exit(1)
+        raise DefaultBranchError()
     return repo_root, default_branch
 
 
@@ -252,8 +263,7 @@ def _resolve_session_type(repo_root: Path, worktree: bool, yes: bool) -> bool:
         console.print(f"[yellow]Warning:[/yellow] Main repository already has a session: '{existing_main.name}'")
         if yes or Confirm.ask("Create a worktree instead?", default=True):
             return True
-        console.print("[red]Aborted:[/red] Main repository already in use.")
-        sys.exit(1)
+        raise UserAbortedError("Main repository already in use.")
     return False
 
 
@@ -292,8 +302,7 @@ def _setup_worktree(repo_root: Path, session_path: Path, default_branch: str, na
             create_worktree(repo_root, session_path, default_branch)
             console.print(f"  [green]\u2713[/green] Created detached worktree from {default_branch}")
         except subprocess.CalledProcessError as e:
-            console.print(f"[red]Error creating worktree:[/red] {e}", style="bold")
-            sys.exit(1)
+            raise WorktreeError("creation", str(e)) from e
     run_post_create(repo_root, session_path, name)
 
 
@@ -384,8 +393,7 @@ def _create_new_session_window(name: str, path: str, launch_cmd: str, is_first: 
     if is_first:
         cc_window_id = create_tmux_session(INNER_SESSION, name, path, launch_cmd)
         if cc_window_id is None:
-            console.print(f"[red]Error creating tmux session[/red]", style="bold")
-            sys.exit(1)
+            raise TmuxError("session creation")
         apply_server_global_config()
         bash_window_id = create_bash_window(name, path)
         console.print(f"  [green]\u2713[/green] Created tmux session '{INNER_SESSION}' with window '{name}'")
@@ -398,8 +406,7 @@ def _create_new_session_window(name: str, path: str, launch_cmd: str, is_first: 
     else:
         cc_window_id = create_tmux_window(INNER_SESSION, name, path, launch_cmd)
         if cc_window_id is None:
-            console.print(f"[red]Error creating tmux window[/red]", style="bold")
-            sys.exit(1)
+            raise TmuxError("window creation")
         bash_window_id = create_bash_window(name, path)
         select_window(INNER_SESSION, name)
         console.print(f"  [green]\u2713[/green] Created new window '{name}'")
@@ -441,21 +448,18 @@ def _resolve_rename_args(old: Optional[str], new: Optional[str]) -> tuple[str, s
         new_name = sanitize_name(new)
         session_data = state.get_session(old_name)
         if not session_data:
-            console.print(f"[red]Error:[/red] Session '{old_name}' not found.", style="bold")
-            sys.exit(1)
+            raise SessionNotFoundError(old_name)
     elif old is not None and new is None:
         new_name = sanitize_name(old)
         detected = detect_current_ccmux_session_any()
         if not detected:
-            console.print("[red]Error:[/red] Not in a ccmux session.", style="bold")
-            sys.exit(1)
+            raise NotInCcmuxSessionError()
         old_name = detected[0]
         session_data = detected[1]
     elif old is None and new is None:
         old_name, new_name, session_data = _interactive_rename()
     else:
-        console.print("[red]Error:[/red] Provide both old and new names, one name to rename current session, or run without args for interactive mode.", style="bold")
-        sys.exit(1)
+        raise InvalidArgumentError("Provide both old and new names, one name to rename current session, or run without args for interactive mode.")
     return old_name, new_name, session_data
 
 
@@ -463,8 +467,7 @@ def _interactive_rename() -> tuple[str, str, object]:
     """Handle interactive rename mode."""
     sessions = state.get_all_sessions()
     if not sessions:
-        console.print(f"[yellow]No sessions found.[/yellow]")
-        sys.exit(0)
+        raise NoSessionsFound()
 
     console.print(f"\n[bold]Sessions:[/bold]")
     for i, sess in enumerate(sessions):
@@ -499,14 +502,14 @@ def _rename_active_worktree(old_name: str, new_name: str, session_data) -> None:
             move_worktree(repo_path, old_path, new_path)
             console.print(f"  [green]\u2713[/green] Moved worktree directory: {old_path.name} -> {new_path.name}")
         except subprocess.CalledProcessError as e:
-            console.print(f"[red]Error moving worktree:[/red] {e}", style="bold")
-            sys.exit(1)
+            raise WorktreeError("move", str(e)) from e
 
     migrated = _migrate_session_data(session_data, old_path, new_path)
 
     if not state.rename_session(old_name, new_name):
-        _print_rename_error(old_name, new_name)
-        sys.exit(1)
+        if not state.get_session(old_name):
+            raise SessionNotFoundError(old_name)
+        raise SessionExistsError(new_name)
     state.update_session(new_name, session_path=str(new_path))
 
     new_cc_window_id = _create_renamed_window(new_name, new_path, session_data, migrated)
@@ -590,20 +593,21 @@ def _rename_inactive_worktree(old_name: str, new_name: str, session_data) -> Non
             move_worktree(repo_path, old_path, new_path)
             console.print(f"  [green]\u2713[/green] Moved worktree directory: {old_path.name} -> {new_path.name}")
         except subprocess.CalledProcessError as e:
-            console.print(f"[red]Error moving worktree:[/red] {e}", style="bold")
-            sys.exit(1)
+            raise WorktreeError("move", str(e)) from e
 
     if not state.rename_session(old_name, new_name):
-        _print_rename_error(old_name, new_name)
-        sys.exit(1)
+        if not state.get_session(old_name):
+            raise SessionNotFoundError(old_name)
+        raise SessionExistsError(new_name)
     state.update_session(new_name, session_path=str(new_path))
 
 
 def _rename_main_repo_session(old_name: str, new_name: str, session_data, is_active: bool) -> None:
     """Rename a main repo (non-worktree) session."""
     if not state.rename_session(old_name, new_name):
-        _print_rename_error(old_name, new_name)
-        sys.exit(1)
+        if not state.get_session(old_name):
+            raise SessionNotFoundError(old_name)
+        raise SessionExistsError(new_name)
 
     if is_active:
         tmux_cc_window_id = session_data.tmux_cc_window_id
@@ -613,13 +617,6 @@ def _rename_main_repo_session(old_name: str, new_name: str, session_data, is_act
             console.print(f"  [yellow]\u26a0[/yellow] Could not rename tmux window")
         rename_tmux_window(f"{BASH_SESSION}:{old_name}", new_name)
 
-
-def _print_rename_error(old_name: str, new_name: str) -> None:
-    """Print rename error message."""
-    if not state.get_session(old_name):
-        console.print(f"[red]Error:[/red] Session '{old_name}' not found.", style="bold")
-    else:
-        console.print(f"[red]Error:[/red] Session '{new_name}' already exists.", style="bold")
 
 
 def do_session_rename(old: Optional[str] = None, new: Optional[str] = None) -> None:
@@ -736,9 +733,7 @@ def _remove_single_session(name: str, sessions: list, yes: bool) -> None:
     session = find_session_by_name(sessions, name)
 
     if session is None:
-        console.print(f"[red]Error:[/red] Session '{name}' not found.", style="bold")
-        console.print(f"List sessions with: [cyan]ccmux list[/cyan]")
-        sys.exit(1)
+        raise SessionNotFoundError(name, "List sessions with: ccmux list")
 
     is_active = session in active
     is_main_repo = not session.is_worktree
@@ -824,17 +819,17 @@ def do_session_remove(name: Optional[str] = None, yes: bool = False, all_session
         if detected:
             name = detected[0]
         else:
-            console.print("[red]Error:[/red] No session name provided and could not auto-detect.", style="bold")
-            console.print("  Run from within a ccmux session, or specify a name:")
-            console.print("    [cyan]ccmux remove <name>[/cyan]")
-            console.print("  To remove all sessions:")
-            console.print("    [cyan]ccmux remove --all[/cyan]")
-            sys.exit(1)
+            raise InvalidArgumentError(
+                "No session name provided and could not auto-detect.\n"
+                "  Run from within a ccmux session, or specify a name:\n"
+                "    ccmux remove <name>\n"
+                "  To remove all sessions:\n"
+                "    ccmux remove --all"
+            )
 
     sessions = state.get_all_sessions()
     if not sessions:
-        console.print(f"[yellow]No sessions found.[/yellow]")
-        sys.exit(0)
+        raise NoSessionsFound()
 
     if name is None:
         _remove_all_sessions(sessions, yes)
@@ -881,8 +876,7 @@ def _deactivate_single_session(name: str, sessions: list, active_sessions: list)
     """Deactivate a single session."""
     session = find_session_by_name(sessions, name)
     if session is None:
-        console.print(f"[red]Error:[/red] Session '{name}' not found.", style="bold")
-        sys.exit(1)
+        raise SessionNotFoundError(name)
 
     if session not in active_sessions:
         console.print(f"[yellow]Session '{name}' is already inactive.[/yellow]")
@@ -905,8 +899,7 @@ def do_session_deactivate(name: Optional[str] = None, yes: bool = False) -> None
     sessions = state.get_all_sessions()
 
     if not sessions:
-        console.print(f"[yellow]No sessions found.[/yellow]")
-        sys.exit(0)
+        raise NoSessionsFound()
 
     active, _ = partition_sessions_by_active(sessions)
 
@@ -929,9 +922,7 @@ def _activate_all(yes: bool = False) -> None:
     """Activate all inactive sessions."""
     sessions = state.get_all_sessions()
     if not sessions:
-        console.print(f"[yellow]No sessions found.[/yellow]")
-        console.print(f"Create one with: [cyan]ccmux new[/cyan]")
-        sys.exit(0)
+        raise NoSessionsFound("Create one with: ccmux new")
 
     _, inactive = partition_sessions_by_active(sessions)
     if not inactive:
@@ -980,15 +971,11 @@ def _activate_single(name: str, yes: bool = False) -> None:
     """Activate a single session by name."""
     sessions = state.get_all_sessions()
     if not sessions:
-        console.print(f"[yellow]No sessions found.[/yellow]")
-        console.print(f"Create one with: [cyan]ccmux new[/cyan]")
-        sys.exit(0)
+        raise NoSessionsFound("Create one with: ccmux new")
 
     session = find_session_by_name(sessions, name)
     if session is None:
-        console.print(f"[red]Error:[/red] Session '{name}' not found.", style="bold")
-        console.print(f"List sessions with: [cyan]ccmux list[/cyan]")
-        sys.exit(1)
+        raise SessionNotFoundError(name, "List sessions with: ccmux list")
 
     if is_session_window_active(session.tmux_cc_window_id):
         ensure_outer_session()
@@ -1008,8 +995,7 @@ def _activate_single(name: str, yes: bool = False) -> None:
     cc_window_id, bash_window_id = create_session_window(name, session.session_path, launch_cmd, is_first)
 
     if cc_window_id is None:
-        console.print(f"[red]Error activating Claude Code[/red]", style="bold")
-        sys.exit(1)
+        raise ActivationError(name)
 
     if is_first:
         console.print(f"  [green]\u2713[/green] Created tmux session and activated '{name}'")
@@ -1144,34 +1130,27 @@ def _try_cwd_match() -> bool:
 def do_detach(all_clients: bool = False) -> None:
     """Detach the ccmux tmux session."""
     if not tmux_session_exists(OUTER_SESSION):
-        console.print(f"[red]Error:[/red] No active ccmux session.", style="bold")
-        sys.exit(1)
+        raise DetachError("No active ccmux session.")
     try:
         if all_clients:
             detach_client(session=OUTER_SESSION)
         else:
             clients = list_clients(OUTER_SESSION)
             if not clients:
-                console.print("[red]Error:[/red] No clients attached to ccmux session.", style="bold")
-                sys.exit(1)
+                raise DetachError("No clients attached to ccmux session.")
             detach_client(client_tty=clients[0])
     except subprocess.CalledProcessError as e:
-        console.print(f"[red]Error detaching:[/red] {e}", style="bold")
-        sys.exit(1)
+        raise DetachError(f"Detach failed: {e}") from e
 
 
 def do_attach() -> None:
     """Attach to the ccmux tmux session."""
     sessions = state.get_all_sessions()
     if not sessions:
-        console.print(f"[red]Error:[/red] No ccmux session found.", style="bold")
-        console.print(f"\nCreate a session with: [cyan]ccmux new[/cyan]")
-        sys.exit(1)
+        raise AttachError("No ccmux session found.", "Create a session with: ccmux new")
 
     if not tmux_session_exists(INNER_SESSION):
-        console.print(f"[red]Error:[/red] Tmux session no longer exists.", style="bold")
-        console.print(f"\nThe tmux session was closed. Activate sessions with: [cyan]ccmux activate[/cyan]")
-        sys.exit(1)
+        raise AttachError("Tmux session no longer exists.", "Activate sessions with: ccmux activate")
 
     ensure_outer_session()
     notify_sidebars()
@@ -1182,7 +1161,7 @@ def do_session_which() -> None:
     """Print the current session name (useful for scripting)."""
     detected = detect_current_ccmux_session_any()
     if detected is None:
-        sys.exit(1)
+        raise NotInCcmuxSessionError()
     print(detected[0])
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,263 @@
+"""Tests for ccmux exception classes and CLI error handling."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+from ccmux.exceptions import (
+    ActivationError,
+    AttachError,
+    CcmuxError,
+    DefaultBranchError,
+    DetachError,
+    InvalidArgumentError,
+    NoSessionsFound,
+    NotInCcmuxSessionError,
+    NotInGitRepoError,
+    SessionExistsError,
+    SessionNotFoundError,
+    TmuxError,
+    UserAbortedError,
+    WorktreeError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Exception class instantiation and attributes
+# ---------------------------------------------------------------------------
+
+class TestCcmuxError:
+    def test_base_exception(self):
+        e = CcmuxError("something broke")
+        assert str(e) == "something broke"
+        assert e.message == "something broke"
+        assert e.exit_code == 1
+
+    def test_is_exception(self):
+        assert issubclass(CcmuxError, Exception)
+
+
+class TestNoSessionsFound:
+    def test_default(self):
+        e = NoSessionsFound()
+        assert str(e) == "No sessions found."
+        assert e.exit_code == 0
+        assert e.hint == ""
+
+    def test_with_hint(self):
+        e = NoSessionsFound("Create one with: ccmux new")
+        assert e.hint == "Create one with: ccmux new"
+        assert e.exit_code == 0
+
+    def test_is_ccmux_error(self):
+        assert issubclass(NoSessionsFound, CcmuxError)
+
+
+class TestSessionNotFoundError:
+    def test_basic(self):
+        e = SessionNotFoundError("my-session")
+        assert str(e) == "Session 'my-session' not found."
+        assert e.name == "my-session"
+        assert e.hint == ""
+        assert e.exit_code == 1
+
+    def test_with_hint(self):
+        e = SessionNotFoundError("foo", "List sessions with: ccmux list")
+        assert e.hint == "List sessions with: ccmux list"
+
+
+class TestSessionExistsError:
+    def test_basic(self):
+        e = SessionExistsError("dup")
+        assert str(e) == "Session 'dup' already exists."
+        assert e.name == "dup"
+        assert e.exit_code == 1
+
+
+class TestNotInGitRepoError:
+    def test_message(self):
+        e = NotInGitRepoError()
+        assert str(e) == "Not inside a git repository."
+        assert e.exit_code == 1
+
+
+class TestDefaultBranchError:
+    def test_message(self):
+        e = DefaultBranchError()
+        assert str(e) == "Could not detect default branch (main/master)."
+        assert e.exit_code == 1
+
+
+class TestUserAbortedError:
+    def test_with_reason(self):
+        e = UserAbortedError("Main repository already in use.")
+        assert str(e) == "Main repository already in use."
+        assert e.reason == "Main repository already in use."
+
+    def test_without_reason(self):
+        e = UserAbortedError()
+        assert str(e) == "Aborted."
+        assert e.reason == ""
+
+
+class TestTmuxError:
+    def test_without_detail(self):
+        e = TmuxError("session creation")
+        assert str(e) == "Tmux session creation failed."
+        assert e.operation == "session creation"
+        assert e.detail == ""
+
+    def test_with_detail(self):
+        e = TmuxError("window creation", "server not running")
+        assert str(e) == "Tmux window creation failed: server not running"
+        assert e.detail == "server not running"
+
+
+class TestWorktreeError:
+    def test_without_detail(self):
+        e = WorktreeError("creation")
+        assert str(e) == "Worktree creation failed."
+        assert e.operation == "creation"
+
+    def test_with_detail(self):
+        e = WorktreeError("move", "permission denied")
+        assert str(e) == "Worktree move failed: permission denied"
+        assert e.detail == "permission denied"
+
+
+class TestInvalidArgumentError:
+    def test_message(self):
+        e = InvalidArgumentError("Provide both old and new names")
+        assert str(e) == "Provide both old and new names"
+        assert e.exit_code == 1
+
+
+class TestNotInCcmuxSessionError:
+    def test_message(self):
+        e = NotInCcmuxSessionError()
+        assert str(e) == "Not in a ccmux session."
+        assert e.exit_code == 1
+
+
+class TestActivationError:
+    def test_message(self):
+        e = ActivationError("my-session")
+        assert str(e) == "Error activating session 'my-session'."
+        assert e.name == "my-session"
+        assert e.exit_code == 1
+
+
+class TestDetachError:
+    def test_message(self):
+        e = DetachError("No active ccmux session.")
+        assert str(e) == "No active ccmux session."
+        assert e.reason == "No active ccmux session."
+        assert e.exit_code == 1
+
+
+class TestAttachError:
+    def test_without_hint(self):
+        e = AttachError("No ccmux session found.")
+        assert str(e) == "No ccmux session found."
+        assert e.hint == ""
+
+    def test_with_hint(self):
+        e = AttachError("No ccmux session found.", "Create a session with: ccmux new")
+        assert e.hint == "Create a session with: ccmux new"
+        assert e.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# All exceptions inherit from CcmuxError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("exc_class", [
+    NoSessionsFound,
+    SessionNotFoundError,
+    SessionExistsError,
+    NotInGitRepoError,
+    DefaultBranchError,
+    UserAbortedError,
+    TmuxError,
+    WorktreeError,
+    InvalidArgumentError,
+    NotInCcmuxSessionError,
+    ActivationError,
+    DetachError,
+    AttachError,
+])
+def test_all_inherit_from_ccmux_error(exc_class):
+    assert issubclass(exc_class, CcmuxError)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: exception → sys.exit mapping
+# ---------------------------------------------------------------------------
+
+class TestCliExceptionHandling:
+    """Test that cli.main() catches exceptions and exits correctly."""
+
+    def _run_main_with_exception(self, exception):
+        """Run cli.main() where app() raises the given exception."""
+        with mock.patch("ccmux.cli.check_tmux_installed", return_value=True), \
+             mock.patch("ccmux.cli.check_claude_installed", return_value=True), \
+             mock.patch("ccmux.cli.stale_sessions_running", return_value=False), \
+             mock.patch("ccmux.cli.app", side_effect=exception), \
+             mock.patch("ccmux.cli.console") as mock_console:
+            from ccmux.cli import main
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            return exc_info.value.code, mock_console
+
+    def test_no_sessions_found_exits_0(self):
+        code, mock_console = self._run_main_with_exception(NoSessionsFound())
+        assert code == 0
+        mock_console.print.assert_any_call("[yellow]No sessions found.[/yellow]")
+
+    def test_no_sessions_found_with_hint(self):
+        code, mock_console = self._run_main_with_exception(
+            NoSessionsFound("Create one with: ccmux new")
+        )
+        assert code == 0
+        mock_console.print.assert_any_call("  Create one with: ccmux new")
+
+    def test_session_not_found_exits_1(self):
+        code, mock_console = self._run_main_with_exception(
+            SessionNotFoundError("foo")
+        )
+        assert code == 1
+
+    def test_session_not_found_with_hint(self):
+        code, mock_console = self._run_main_with_exception(
+            SessionNotFoundError("foo", "List sessions with: ccmux list")
+        )
+        assert code == 1
+        mock_console.print.assert_any_call("  List sessions with: ccmux list")
+
+    def test_not_in_git_repo_exits_1(self):
+        code, _ = self._run_main_with_exception(NotInGitRepoError())
+        assert code == 1
+
+    def test_keyboard_interrupt_exits_130(self):
+        code, _ = self._run_main_with_exception(KeyboardInterrupt())
+        assert code == 130
+
+    def test_session_exists_exits_1(self):
+        code, _ = self._run_main_with_exception(SessionExistsError("dup"))
+        assert code == 1
+
+    def test_tmux_error_exits_1(self):
+        code, _ = self._run_main_with_exception(TmuxError("session creation"))
+        assert code == 1
+
+    def test_worktree_error_exits_1(self):
+        code, _ = self._run_main_with_exception(WorktreeError("creation", "fail"))
+        assert code == 1
+
+    def test_attach_error_with_hint(self):
+        code, mock_console = self._run_main_with_exception(
+            AttachError("No ccmux session found.", "Create a session with: ccmux new")
+        )
+        assert code == 1
+        mock_console.print.assert_any_call("  Create a session with: ccmux new")


### PR DESCRIPTION
## Summary
- Expands `ccmux/exceptions.py` from 1 class to 13 (1 base `CcmuxError` + 12 specific exception types)
- Replaces all 30 `sys.exit()` calls in `session_ops.py` with structured `raise` statements
- Adds centralized exception handling in `cli.main()` — `NoSessionsFound` exits 0, all other `CcmuxError` subclasses exit 1 with formatted error messages and optional hints
- Removes per-command `try/except` boilerplate from `session_new` and `session_rename`
- Removes `_print_rename_error()` helper and `import sys` from `session_ops.py`
- Adds 45 tests covering exception instantiation, attribute correctness, and CLI integration

## Test plan
- [x] `python -m pytest` — all 151 tests pass
- [x] `grep -c "sys.exit" ccmux/session_ops.py` → 0 (only docstring reference)
- [ ] Manual smoke test: `ccmux list`, `ccmux which` (outside session), `ccmux new` (without git repo)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)