### PR TITLE
fix: Use --resume instead of --session-id for existing sessions

### DIFF
--- a/ccmux/session_ops.py
+++ b/ccmux/session_ops.py
@@ -93,21 +93,13 @@ def stale_sessions_running() -> bool:
 # Shared helpers (extracted from duplicated patterns)
 # ---------------------------------------------------------------------------
 
-def build_launch_command(name: str, path: str, claude_session_id: str) -> str:
-    """Build the shell command to launch Claude Code in a tmux pane."""
+def build_claude_command(name: str, path: str, claude_session_id: str, resume: bool = False) -> str:
+    """Build the shell command to launch or resume Claude Code in a tmux pane."""
+    flag = "--resume" if resume else "--session-id"
     return (
         f"export CCMUX_SESSION={name}; "
         f"unset CLAUDECODE; "
-        f"claude --session-id {claude_session_id}; while true; do $SHELL; done"
-    )
-
-
-def build_activate_command(name: str, path: str, claude_session_id: str) -> str:
-    """Build the shell command to activate Claude Code in a tmux pane."""
-    return (
-        f"export CCMUX_SESSION={name}; "
-        f"unset CLAUDECODE; "
-        f"claude --session-id {claude_session_id}; while true; do $SHELL; done"
+        f"claude {flag} {claude_session_id}; while true; do $SHELL; done"
     )
 
 
@@ -328,7 +320,7 @@ def _reactivate_single_orphan(sess) -> None:
     sess_type = sess.session_type + " repo" if not sess.is_worktree else "worktree"
 
     orphan_session_id = sess.claude_session_id or str(uuid.uuid4())
-    cmd = build_launch_command(name, path, orphan_session_id)
+    cmd = build_claude_command(name, path, orphan_session_id, resume=bool(sess.claude_session_id))
 
     cc_window_id = create_tmux_window(INNER_SESSION, name, path, cmd)
     if cc_window_id:
@@ -360,7 +352,7 @@ def do_session_new(name: Optional[str] = None, worktree: bool = False, yes: bool
 
     session_type = "worktree" if create_as_worktree else "main repo"
     claude_session_id = str(uuid.uuid4())
-    launch_cmd = build_launch_command(name, str(session_path), claude_session_id)
+    launch_cmd = build_claude_command(name, str(session_path), claude_session_id)
 
     cc_window_id, bash_window_id = _create_new_session_window(name, str(session_path), launch_cmd, is_first)
 
@@ -540,15 +532,9 @@ def _create_renamed_window(new_name: str, new_path: Path, session_data, migrated
     old_session_id = session_data.claude_session_id
     new_session_id = old_session_id if migrated else str(uuid.uuid4())
 
-    if migrated and old_session_id:
-        claude_arg = f"claude --resume {old_session_id}"
-    else:
-        claude_arg = f"claude --session-id {new_session_id}"
-
-    launch_cmd = (
-        f"export CCMUX_SESSION={new_name}; "
-        f"unset CLAUDECODE; "
-        f"{claude_arg}; while true; do $SHELL; done"
+    launch_cmd = build_claude_command(
+        new_name, str(new_path), new_session_id,
+        resume=bool(migrated and old_session_id),
     )
 
     window_id = create_tmux_window(INNER_SESSION, new_name, str(new_path), launch_cmd)
@@ -948,7 +934,7 @@ def _activate_all(yes: bool = False) -> None:
             state.clear_tmux_window_ids(sess.name)
         is_first = not inner_exists and i == 0
         claude_session_id = sess.claude_session_id or str(uuid.uuid4())
-        launch_cmd = build_activate_command(sess.name, sess.session_path, claude_session_id)
+        launch_cmd = build_claude_command(sess.name, sess.session_path, claude_session_id, resume=bool(sess.claude_session_id))
 
         cc_window_id, bash_window_id = create_session_window(sess.name, sess.session_path, launch_cmd, is_first)
         if cc_window_id:
@@ -990,7 +976,7 @@ def _activate_single(name: str, yes: bool = False) -> None:
 
     is_first = not tmux_session_exists(INNER_SESSION)
     claude_session_id = session.claude_session_id or str(uuid.uuid4())
-    launch_cmd = build_activate_command(name, session.session_path, claude_session_id)
+    launch_cmd = build_claude_command(name, session.session_path, claude_session_id, resume=bool(session.claude_session_id))
 
     cc_window_id, bash_window_id = create_session_window(name, session.session_path, launch_cmd, is_first)
 

--- a/tests/test_build_claude_command.py
+++ b/tests/test_build_claude_command.py
@@ -1,0 +1,25 @@
+from ccmux.session_ops import build_claude_command
+
+
+def test_new_session_uses_session_id():
+    cmd = build_claude_command("my-session", "/tmp/path", "abc-123", resume=False)
+    assert "--session-id abc-123" in cmd
+    assert "--resume" not in cmd
+
+
+def test_resume_uses_resume_flag():
+    cmd = build_claude_command("my-session", "/tmp/path", "abc-123", resume=True)
+    assert "--resume abc-123" in cmd
+    assert "--session-id" not in cmd
+
+
+def test_default_is_not_resume():
+    cmd = build_claude_command("my-session", "/tmp/path", "abc-123")
+    assert "--session-id abc-123" in cmd
+
+
+def test_command_sets_env_and_shell_loop():
+    cmd = build_claude_command("sess", "/p", "id-1")
+    assert "export CCMUX_SESSION=sess" in cmd
+    assert "unset CLAUDECODE" in cmd
+    assert "while true; do $SHELL; done" in cmd


### PR DESCRIPTION
## Summary
- Consolidate identical `build_launch_command()` and `build_activate_command()` into a single `build_claude_command()` with a `resume` parameter
- Activation paths (`_activate_single`, `_activate_all`, `_reactivate_single_orphan`) now use `--resume` when a `claude_session_id` already exists, fixing the "Session ID ... is already in use" error
- Refactor `_create_renamed_window()` to use `build_claude_command()` instead of inline command-building
- Add unit tests for the new `build_claude_command()` function

## Test plan
- [ ] `ccmux new` — launches with `--session-id` (fresh UUID)
- [ ] Kill tmux session, then `ccmux activate` — launches with `--resume`, no "already in use" error
- [ ] `ccmux activate --all` — same resume behavior for bulk activation
- [ ] `pytest` — all 161 tests pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)