### PR TITLE
fix: Preserve session status when clicking sidebar rows (#34)

### DIFF
--- a/ccmux/ui/sidebar/sidebar_app.py
+++ b/ccmux/ui/sidebar/sidebar_app.py
@@ -5,6 +5,7 @@ import logging
 import os
 import signal
 import subprocess
+import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 
@@ -22,6 +23,7 @@ from ccmux.ui.sidebar.widgets import SessionRow, RepoSessionsList, TitleBanner, 
 
 POLL_INTERVAL = 5.0
 DEMO_POLL_INTERVAL = 1.0
+POST_SELECTION_ACTIVITY_DEBOUNCE = 0.5  # seconds to ignore misleading activity caused by returning focus to the Claude Code window
 
 # --- Logging ---
 _LOG_DIR = Path.home() / ".ccmux"
@@ -61,6 +63,7 @@ class SidebarApp(App):
         self._last_derived: list[DerivedSessionState] | None = None
         self._blocked_sessions: set[str] = set()
         self._blocker_alerted_sessions: set[str] = set()
+        self._post_selection_debounce: dict[str, float] = {}
         self._refresh_lock = asyncio.Lock()
         self._session_list: Vertical | None = None
         self._about_visible = False
@@ -194,8 +197,17 @@ class SidebarApp(App):
             self._blocked_sessions.add(name)
             self._blocker_alerted_sessions.add(name)
         elif raw_alert == "activity":
-            self._blocked_sessions.discard(name)
-            self._blocker_alerted_sessions.discard(name)
+            # If we recently clicked this row, ignore misleading activity
+            # caused by returning focus to the Claude Code window.
+            debounce_ts = self._post_selection_debounce.get(name)
+            if debounce_ts is not None:
+                if entry.activity_ts < debounce_ts + POST_SELECTION_ACTIVITY_DEBOUNCE:
+                    raw_alert = None
+                else:
+                    del self._post_selection_debounce[name]
+            if raw_alert == "activity":
+                self._blocked_sessions.discard(name)
+                self._blocker_alerted_sessions.discard(name)
         # raw_alert is None → sticky state persists (key for blocked persistence)
 
         if raw_alert == "activity":
@@ -308,6 +320,10 @@ class SidebarApp(App):
 
     async def on_session_row_selected(self, message: SessionRow.Selected) -> None:
         """Switch to the clicked session's tmux window and clear blocker alert."""
+        # Record debounce timestamp so that misleading tmux activity from
+        # returning focus to the Claude Code window doesn't change session status.
+        self._post_selection_debounce[message.session_name] = time.time()
+
         # Clear blocker alert (row background) but keep blocked status (red circle)
         self._blocker_alerted_sessions.discard(message.session_name)
         try:

--- a/ccmux/ui/sidebar/snapshot.py
+++ b/ccmux/ui/sidebar/snapshot.py
@@ -29,6 +29,7 @@ class SessionSnapshot:
     short_sha: str = ""
     lines_added: int = 0
     lines_removed: int = 0
+    activity_ts: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,6 +132,7 @@ async def get_tmux_window_flags() -> dict[str, dict]:
                     "bell": parts[1] == "1",
                     "recently_active": (now - activity_ts) < ACTIVITY_TIMEOUT,
                     "sid": parts[3],
+                    "activity_ts": float(activity_ts),
                 }
         return flags
     except subprocess.CalledProcessError:
@@ -225,6 +227,7 @@ async def build_snapshot() -> list[SessionSnapshot]:
         is_current = sess.name == current_session
         sess_type = sess.session_type
         alert_state = resolve_alert_state(wid_flags) if is_active else None
+        activity_ts = wid_flags.get("activity_ts", 0.0) if wid_flags else 0.0
         snapshot.append(SessionSnapshot(
             repo_name=repo_name,
             session_name=sess.name,
@@ -237,5 +240,6 @@ async def build_snapshot() -> list[SessionSnapshot]:
             short_sha=short_sha,
             lines_added=added,
             lines_removed=removed,
+            activity_ts=activity_ts,
         ))
     return snapshot

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -306,6 +306,85 @@ class TestStickyBlockedState:
             assert status == "blocked"
 
 
+class TestPostSelectionActivityDebounce:
+    """Tests for the post-selection debounce that prevents misleading activity from changing status."""
+
+    def _make_app(self):
+        app = SidebarApp(snapshot_fn=lambda: [], poll_interval=60.0)
+        return app
+
+    def _snap(self, name="fox", is_active=True, alert_state=None, activity_ts=0.0):
+        from ccmux.ui.sidebar.snapshot import SessionSnapshot
+        return SessionSnapshot(
+            repo_name="repo", session_name=name, session_type="worktree",
+            is_active=is_active, is_current=False, alert_state=alert_state,
+            session_id=1, activity_ts=activity_ts,
+        )
+
+    def test_post_selection_activity_does_not_clear_blocked(self):
+        """Activity from window focus should not clear blocked status after click."""
+        import time
+        app = self._make_app()
+        # Bell fires — session becomes blocked
+        app._compute_session_state(self._snap(alert_state="bell"))
+        assert "fox" in app._blocked_sessions
+
+        # Simulate clicking the blocked row
+        click_time = time.time()
+        app._post_selection_debounce["fox"] = click_time
+
+        # Activity arrives with timestamp *before* debounce cutoff (misleading window-focus activity)
+        status, has_alert = app._compute_session_state(
+            self._snap(alert_state="activity", activity_ts=click_time + 0.1),
+        )
+        assert status == "blocked"
+        assert "fox" in app._blocked_sessions
+
+    def test_real_activity_clears_blocked_after_debounce(self):
+        """Activity with timestamp after debounce window should clear blocked status."""
+        import time
+        app = self._make_app()
+        # Bell fires — session becomes blocked
+        app._compute_session_state(self._snap(alert_state="bell"))
+        assert "fox" in app._blocked_sessions
+
+        # Simulate clicking the blocked row
+        click_time = time.time() - 1.0  # click happened 1 second ago
+        app._post_selection_debounce["fox"] = click_time
+
+        # Activity arrives with timestamp well after the debounce cutoff
+        status, has_alert = app._compute_session_state(
+            self._snap(alert_state="activity", activity_ts=click_time + 1.0),
+        )
+        assert status == "active"
+        assert "fox" not in app._blocked_sessions
+        # Debounce entry should be cleaned up
+        assert "fox" not in app._post_selection_debounce
+
+    def test_activity_without_debounce_clears_normally(self):
+        """Activity on a blocked session with no debounce entry clears blocked status normally."""
+        app = self._make_app()
+        # Bell fires — session becomes blocked
+        app._compute_session_state(self._snap(alert_state="bell"))
+        assert "fox" in app._blocked_sessions
+
+        # No debounce entry (no click happened) — activity clears normally
+        status, has_alert = app._compute_session_state(
+            self._snap(alert_state="activity", activity_ts=9999999999.0),
+        )
+        assert status == "active"
+        assert "fox" not in app._blocked_sessions
+
+    def test_activity_without_click_not_debounced(self):
+        """Activity on a session with no debounce entry is not affected."""
+        app = self._make_app()
+        # Session is idle (no click happened) — activity should set active
+        status, has_alert = app._compute_session_state(
+            self._snap(alert_state="activity", activity_ts=0.0),
+        )
+        assert status == "active"
+
+
 class TestPidTracking:
     """Tests for PID file management."""
 


### PR DESCRIPTION
Add a post-selection activity debounce so that misleading tmux activity caused by returning focus to the Claude Code window doesn't change session status.  When a row is clicked, activity whose timestamp falls within the debounce window is ignored.  This preserves both blocked (red circle) and idle states until the user actually interacts with the Claude Code session.