### PR TITLE
feat: Single-purpose branch detection with fallback chain

### DIFF
--- a/ccmux/git_ops.py
+++ b/ccmux/git_ops.py
@@ -26,7 +26,7 @@ def get_repo_root() -> Optional[Path]:
 
 
 def get_default_branch() -> Optional[str]:
-    """Get the default branch name (main, master, etc.)."""
+    """Get the default branch name from the remote origin."""
     try:
         result = subprocess.run(
             ["git", "remote", "show", "origin"],
@@ -37,6 +37,32 @@ def get_default_branch() -> Optional[str]:
         for line in result.stdout.split("\n"):
             if "HEAD branch:" in line:
                 return line.split(":")[-1].strip()
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+
+def check_for_common_default_branches() -> Optional[str]:
+    """Check for common default branch names (main, master) locally."""
+    for name in ("main", "master"):
+        if branch_exists(name):
+            return name
+    return None
+
+
+def get_most_recently_used_branch() -> Optional[str]:
+    """Get the branch with the most recent commit."""
+    try:
+        result = subprocess.run(
+            ["git", "for-each-ref", "--sort=-committerdate",
+             "--format=%(refname:short)", "refs/heads/", "--count=1"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        branch = result.stdout.strip()
+        if branch:
+            return branch
     except subprocess.CalledProcessError:
         pass
     return None

--- a/ccmux/session_ops.py
+++ b/ccmux/session_ops.py
@@ -34,8 +34,10 @@ from ccmux.exceptions import (
     WorktreeError,
 )
 from ccmux.git_ops import (
+    check_for_common_default_branches,
     create_worktree,
     get_default_branch,
+    get_most_recently_used_branch,
     get_repo_root,
     move_worktree,
     remove_worktree,
@@ -251,7 +253,11 @@ def _validate_repo_context() -> tuple[Path, str]:
         raise NotInGitRepoError()
     os.chdir(repo_root)
 
-    default_branch = get_default_branch()
+    default_branch = (
+        get_default_branch()
+        or check_for_common_default_branches()
+        or get_most_recently_used_branch()
+    )
     if default_branch is None:
         raise DefaultBranchError()
     return repo_root, default_branch

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,0 +1,82 @@
+"""Tests for ccmux.git_ops branch detection functions."""
+
+import subprocess
+from unittest.mock import patch
+
+from ccmux.git_ops import (
+    check_for_common_default_branches,
+    get_default_branch,
+    get_most_recently_used_branch,
+)
+
+
+def _make_completed_process(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+class TestGetDefaultBranch:
+    """Tests for get_default_branch() — remote only, no fallback."""
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_branch_from_remote(self, mock_run):
+        """Remote detection returns the HEAD branch."""
+        mock_run.return_value = _make_completed_process(
+            "* remote origin\n  HEAD branch: develop\n"
+        )
+        assert get_default_branch() == "develop"
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_none_on_remote_failure(self, mock_run):
+        """Returns None when remote check fails (no fallback)."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+        assert get_default_branch() is None
+
+
+class TestCheckForCommonDefaultBranches:
+    """Tests for check_for_common_default_branches()."""
+
+    @patch("ccmux.git_ops.branch_exists")
+    def test_returns_main_when_exists(self, mock_branch_exists):
+        """Returns 'main' when it exists locally."""
+        mock_branch_exists.side_effect = lambda name: name == "main"
+        assert check_for_common_default_branches() == "main"
+
+    @patch("ccmux.git_ops.branch_exists")
+    def test_falls_back_to_master(self, mock_branch_exists):
+        """Returns 'master' when 'main' doesn't exist but 'master' does."""
+        mock_branch_exists.side_effect = lambda name: name == "master"
+        assert check_for_common_default_branches() == "master"
+
+    @patch("ccmux.git_ops.branch_exists")
+    def test_prefers_main_over_master(self, mock_branch_exists):
+        """When both 'main' and 'master' exist, prefers 'main'."""
+        mock_branch_exists.return_value = True
+        assert check_for_common_default_branches() == "main"
+
+    @patch("ccmux.git_ops.branch_exists")
+    def test_returns_none_when_neither_exists(self, mock_branch_exists):
+        """Returns None when neither 'main' nor 'master' exists."""
+        mock_branch_exists.return_value = False
+        assert check_for_common_default_branches() is None
+
+
+class TestGetMostRecentlyUsedBranch:
+    """Tests for get_most_recently_used_branch()."""
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_most_recent_branch(self, mock_run):
+        """Returns the branch with the most recent commit."""
+        mock_run.return_value = _make_completed_process("feature-x\n")
+        assert get_most_recently_used_branch() == "feature-x"
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_none_on_failure(self, mock_run):
+        """Returns None when git command fails."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+        assert get_most_recently_used_branch() is None
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_none_on_empty_output(self, mock_run):
+        """Returns None when no branches exist."""
+        mock_run.return_value = _make_completed_process("")
+        assert get_most_recently_used_branch() is None


### PR DESCRIPTION
## Summary
- Reverted `get_default_branch()` to remote-only (no local fallback)
- Added `check_for_common_default_branches()` to check for local `main`/`master`
- Added `get_most_recently_used_branch()` as a last-resort fallback using most recent commit
- `_validate_repo_context()` chains all three via `or` for graceful degradation when no remote is configured

Closes #41

## Test plan
- [x] `pytest tests/test_git_ops.py -v` — 9 tests passing
- [ ] Manual: test `ccmux new` in a repo with a remote origin
- [ ] Manual: test `ccmux new` in a local-only repo with a `main` branch
- [ ] Manual: test `ccmux new` in a local-only repo with only non-standard branch names

🤖 Generated with [Claude Code](https://claude.com/claude-code)