### PR TITLE
feat: Update CLI to use workspace/session terminology

### DIFF
--- a/ccmux/cli.py
+++ b/ccmux/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Claude Code Multiplexer CLI - Manage multiple Claude Code sessions."""
+"""Claude Code Multiplexer CLI - Manage Claude Code sessions in a shared workspace."""
 
 import shutil
 import sys
@@ -13,7 +13,6 @@ from ccmux import __version__
 from ccmux.display import console
 from ccmux.exceptions import CcmuxError, NoSessionsFound
 from ccmux.naming import BASH_SESSION, INNER_SESSION, OUTER_SESSION
-from ccmux.session_layout import do_debug_sidebar
 from ccmux.session_ops import (
     do_attach,
     do_detach,
@@ -34,7 +33,7 @@ from ccmux.tmux_ops import check_tmux_installed, kill_all_ccmux_sessions
 app = cyclopts.App(
     name="ccmux",
     version=__version__,
-    help="Claude Code Multiplexer - Manage multiple Claude Code sessions.",
+    help="Claude Code Multiplexer - Manage Claude Code sessions in a shared workspace.",
 )
 
 
@@ -65,7 +64,7 @@ def session_new(
 
 @app.command(name="list")
 def session_list() -> None:
-    """List all sessions and their tmux session status."""
+    """List all sessions in the workspace."""
     do_session_list()
 
 
@@ -74,13 +73,13 @@ def session_rename(
     old: Optional[str] = None,
     new: Optional[str] = None,
 ) -> None:
-    """Rename a ccmux session."""
+    """Rename a session."""
     do_session_rename(old=old, new=new)
 
 
 @app.command(name="attach")
 def attach() -> None:
-    """Attach to the ccmux tmux session."""
+    """Attach to the workspace. (connects to the ccmux terminal UI via tmux)"""
     do_attach()
 
 
@@ -90,7 +89,7 @@ def session_activate(
     *,
     yes: Annotated[bool, Parameter(name=["-y", "--yes"], negative="")] = False,
 ) -> None:
-    """Activate Claude Code in a session (useful if tmux window was closed)."""
+    """Activate Claude Code in a session (useful if its window was closed)."""
     do_session_activate(name=name, yes=yes)
 
 
@@ -100,7 +99,7 @@ def session_deactivate(
     *,
     yes: Annotated[bool, Parameter(name=["-y", "--yes"], negative="")] = False,
 ) -> None:
-    """Deactivate Claude Code session(s) by killing tmux window (keeps session)."""
+    """Deactivate Claude Code session(s) by closing their windows (keeps session data)."""
     do_session_deactivate(name=name, yes=yes)
 
 
@@ -109,7 +108,7 @@ def session_kill(
     *,
     yes: Annotated[bool, Parameter(name=["-y", "--yes"], negative="")] = False,
 ) -> None:
-    """Kill the entire ccmux session."""
+    """Deactivate all sessions and shut down the workspace."""
     do_session_kill(yes=yes)
 
 
@@ -129,14 +128,9 @@ def detach(
     *,
     all_clients: Annotated[bool, Parameter(name=["-a", "--all"], negative="")] = False,
 ) -> None:
-    """Detach the ccmux tmux session."""
+    """Detach from the workspace. (leaves it running in the background)"""
     do_detach(all_clients=all_clients)
 
-
-@app.command(name="debug")
-def debug_sidebar() -> None:
-    """Launch a debug session to isolate sidebar rendering issues."""
-    do_debug_sidebar()
 
 
 def check_claude_installed() -> bool:
@@ -176,14 +170,14 @@ def main():
                 f"(now {__version__})"
             )
         console.print(
-            "Running tmux sessions use outdated hooks and may behave unexpectedly."
+            "The running workspace uses outdated hooks and may behave unexpectedly."
         )
         console.print(
             "Killing them is safe — sessions will be recreated on "
             "[bold]ccmux new[/bold] / [bold]ccmux activate[/bold].\n"
         )
 
-        if Confirm.ask("Kill stale ccmux tmux sessions?", default=True):
+        if Confirm.ask("Shut down the stale workspace?", default=True):
             kill_all_ccmux_sessions(OUTER_SESSION, OUTER_SESSION, INNER_SESSION, BASH_SESSION)
             console.print(
                 "[green]Done.[/green] Run [bold]ccmux new[/bold] or "
@@ -191,7 +185,7 @@ def main():
             )
         else:
             console.print(
-                "[dim]Keeping existing sessions — behavior may be degraded.[/dim]"
+                "[dim]Keeping existing workspace — behavior may be degraded.[/dim]"
             )
 
     try:

--- a/ccmux/display.py
+++ b/ccmux/display.py
@@ -28,7 +28,7 @@ def display_session_table() -> None:
     table.add_column("Type", style="green")
     table.add_column("Branch")
     table.add_column("Status", style="bold")
-    table.add_column("Tmux Window", style="blue")
+    table.add_column("Window", style="blue")
     table.add_column("Path", style="dim")
 
     active_count = 0

--- a/ccmux/exceptions.py
+++ b/ccmux/exceptions.py
@@ -99,7 +99,7 @@ class NotInCcmuxSessionError(CcmuxError):
     """Not currently inside a ccmux session."""
 
     def __init__(self):
-        super().__init__("Not in a ccmux session.")
+        super().__init__("Not in a workspace session.")
 
 
 class ActivationError(CcmuxError):

--- a/ccmux/session_layout.py
+++ b/ccmux/session_layout.py
@@ -1,4 +1,4 @@
-"""Session layout management: sidebar hooks, outer session, bash windows, debug."""
+"""Session layout management: sidebar hooks, outer session, bash windows."""
 
 import os
 import signal
@@ -190,36 +190,3 @@ def _create_bash_session(bash: str, session_name: str, working_dir: str, bash_cm
     return window_id
 
 
-# ---------------------------------------------------------------------------
-# Debug sidebar
-# ---------------------------------------------------------------------------
-
-def do_debug_sidebar() -> None:
-    """Launch a debug session to isolate sidebar rendering issues."""
-    session_name = "ccmux-debug"
-    python_exe = sys.executable or "python3"
-
-    if tmux_session_exists(session_name):
-        kill_tmux_session(session_name)
-
-    sidebar_cmd = (
-        f"COLORTERM=truecolor "
-        f"{python_exe} -m ccmux.ui.sidebar --demo ; "
-        f"echo 'Sidebar exited. Press enter to close.' ; read"
-    )
-
-    try:
-        create_session_simple(session_name, sidebar_cmd)
-        apply_outer_session_config(session_name)
-        split_window(f"{session_name}:0.0", "-v", str(BASH_PANE_HEIGHT), "bash")
-        split_window(f"{session_name}:0.0", "-h", "50%", "bash")
-        resize_pane(f"{session_name}:0.0", SIDEBAR_WIDTH)
-        select_pane(f"{session_name}:0.1")
-    except Exception as exc:
-        console.print(
-            f"[red]Error:[/red] Failed to create debug session: {exc}",
-            style="bold",
-        )
-        sys.exit(1)
-
-    os.execvp("tmux", ["tmux", "attach", "-t", f"={session_name}"])

--- a/ccmux/session_ops.py
+++ b/ccmux/session_ops.py
@@ -90,7 +90,7 @@ def _major_minor(version: str) -> str:
 
 
 def stale_sessions_running() -> bool:
-    """Return True if ccmux tmux sessions are running on an outdated major.minor version."""
+    """Return True if the workspace is running on an outdated major.minor version."""
     if not tmux_session_exists(INNER_SESSION):
         return False
     stored = state.get_tmux_session_version()
@@ -130,9 +130,9 @@ def create_session_window(
             apply_server_global_config()
             bash_window_id = create_bash_window(name, path)
             if apply_claude_inner_session_config(INNER_SESSION):
-                console.print(f"  [green]\u2713[/green] Applied ccmux tmux configuration")
+                console.print(f"  [green]\u2713[/green] Applied workspace configuration")
             else:
-                console.print(f"  [yellow]\u26a0[/yellow] Could not apply tmux configuration (session will use defaults)")
+                console.print(f"  [yellow]\u26a0[/yellow] Could not apply workspace configuration (session will use defaults)")
         return cc_window_id, bash_window_id
     else:
         cc_window_id = create_tmux_window(INNER_SESSION, name, path, launch_cmd)
@@ -204,7 +204,7 @@ def auto_attach_if_outside_tmux(yes: bool = False) -> None:
     """Prompt and attach to tmux if not already inside tmux."""
     if "TMUX" not in os.environ:
         console.print()
-        if yes or Confirm.ask("Attach to tmux session now?", default=True):
+        if yes or Confirm.ask("Attach to workspace now?", default=True):
             os.execvp("tmux", ["tmux", "attach", "-t", f"={OUTER_SESSION}"])
 
 
@@ -405,11 +405,11 @@ def _create_new_session_window(name: str, path: str, launch_cmd: str, is_first: 
             raise TmuxError("session creation")
         apply_server_global_config()
         bash_window_id = create_bash_window(name, path)
-        console.print(f"  [green]\u2713[/green] Created tmux session '{INNER_SESSION}' with window '{name}'")
+        console.print(f"  [green]\u2713[/green] Created workspace with session '{name}'")
         if apply_claude_inner_session_config(INNER_SESSION):
-            console.print(f"  [green]\u2713[/green] Applied ccmux tmux configuration")
+            console.print(f"  [green]\u2713[/green] Applied workspace configuration")
         else:
-            console.print(f"  [yellow]\u26a0[/yellow] Could not apply tmux configuration (session will use defaults)")
+            console.print(f"  [yellow]\u26a0[/yellow] Could not apply workspace configuration (session will use defaults)")
         create_outer_session()
         state.set_tmux_session_version(__version__)
     else:
@@ -623,7 +623,7 @@ def _rename_main_repo_session(old_name: str, new_name: str, session_data, is_act
 
 
 def do_session_rename(old: Optional[str] = None, new: Optional[str] = None) -> None:
-    """Rename a ccmux session."""
+    """Rename a session."""
     old_name, new_name, session_data = _resolve_rename_args(old, new)
 
     if old_name == new_name:
@@ -723,11 +723,11 @@ def _remove_all_sessions(sessions: list, yes: bool) -> None:
 def _kill_remove_all_sessions() -> None:
     """Kill all tmux sessions after removing all sessions."""
     if kill_tmux_session(OUTER_SESSION):
-        console.print(f"\n[green]\u2713[/green] Killed outer tmux session '{OUTER_SESSION}'")
+        console.print(f"\n[green]\u2713[/green] Stopped workspace UI session '{OUTER_SESSION}'")
     if kill_tmux_session(INNER_SESSION):
-        console.print(f"[green]\u2713[/green] Killed inner tmux session '{INNER_SESSION}'")
+        console.print(f"[green]\u2713[/green] Stopped workspace inner session '{INNER_SESSION}'")
     if kill_tmux_session(BASH_SESSION):
-        console.print(f"[green]\u2713[/green] Killed bash tmux session '{BASH_SESSION}'")
+        console.print(f"[green]\u2713[/green] Stopped workspace bash session '{BASH_SESSION}'")
 
 
 def _remove_single_session(name: str, sessions: list, yes: bool) -> None:
@@ -824,7 +824,7 @@ def do_session_remove(name: Optional[str] = None, yes: bool = False, all_session
         else:
             raise InvalidArgumentError(
                 "No session name provided and could not auto-detect.\n"
-                "  Run from within a ccmux session, or specify a name:\n"
+                "  Run from within a workspace session, or specify a name:\n"
                 "    ccmux remove <name>\n"
                 "  To remove all sessions:\n"
                 "    ccmux remove --all"
@@ -957,7 +957,7 @@ def _activate_all(yes: bool = False) -> None:
         if cc_window_id:
             if is_first:
                 inner_exists = True
-                console.print(f"  [green]\u2713[/green] Created tmux session and activated '{sess.name}'")
+                console.print(f"  [green]\u2713[/green] Created workspace and activated '{sess.name}'")
             else:
                 console.print(f"  [green]\u2713[/green] Activated '{sess.name}'")
             update_session_tmux_state(sess.name, claude_session_id, cc_window_id, bash_window_id)
@@ -982,7 +982,7 @@ def _activate_single(name: str, yes: bool = False) -> None:
 
     if is_session_window_active(session.tmux_cc_window_id):
         ensure_outer_session()
-        console.print(f"[yellow]Session '{name}' already has an active tmux window.[/yellow]")
+        console.print(f"[yellow]Session '{name}' is already active.[/yellow]")
         return
 
     if session.tmux_cc_window_id:
@@ -1001,7 +1001,7 @@ def _activate_single(name: str, yes: bool = False) -> None:
         raise ActivationError(name)
 
     if is_first:
-        console.print(f"  [green]\u2713[/green] Created tmux session and activated '{name}'")
+        console.print(f"  [green]\u2713[/green] Created workspace and activated '{name}'")
     else:
         select_window(INNER_SESSION, name)
         console.print(f"  [green]\u2713[/green] Activated '{name}'")
@@ -1028,7 +1028,7 @@ def do_session_activate(name: Optional[str] = None, yes: bool = False) -> None:
 # ---------------------------------------------------------------------------
 
 def do_session_kill(yes: bool = False) -> None:
-    """Kill the entire ccmux session."""
+    """Deactivate all sessions and shut down the workspace."""
     sessions = state.get_all_sessions()
 
     active = [
@@ -1037,23 +1037,23 @@ def do_session_kill(yes: bool = False) -> None:
     ]
 
     if not active and not tmux_session_exists(OUTER_SESSION):
-        console.print("[yellow]No active ccmux session to kill.[/yellow]")
+        console.print("[yellow]No active workspace to shut down.[/yellow]")
         return
 
     if active:
-        console.print(f"\n[bold red]Killing ccmux session with {len(active)} active session(s):[/bold red]")
+        console.print(f"\n[bold red]Shutting down workspace with {len(active)} active session(s):[/bold red]")
         for sess in active:
             console.print(f"  \u2022 {sess.name}")
     else:
-        console.print("\n[bold red]Killing ccmux session (no active sessions)[/bold red]")
+        console.print("\n[bold red]Shutting down workspace (no active sessions)[/bold red]")
 
     if not yes:
-        if not Confirm.ask("Kill the entire ccmux session?", default=False):
+        if not Confirm.ask("Shut down the workspace?", default=False):
             console.print("[yellow]Cancelled.[/yellow]")
             return
 
     kill_all_ccmux_sessions(OUTER_SESSION, OUTER_SESSION, INNER_SESSION, BASH_SESSION)
-    console.print("\n[bold green]Killed ccmux session.[/bold green]")
+    console.print("\n[bold green]Workspace shut down.[/bold green]")
 
 
 # ---------------------------------------------------------------------------
@@ -1075,7 +1075,7 @@ def do_session_info() -> None:
 
     repo_root = get_repo_root()
     if repo_root is None:
-        console.print("[yellow]Not in a ccmux session or git repository.[/yellow]\n")
+        console.print("[yellow]Not in a workspace session or git repository.[/yellow]\n")
         return None  # signal to cli.py to print help
 
     do_session_new(yes=True)
@@ -1131,29 +1131,29 @@ def _try_cwd_match() -> bool:
 # ---------------------------------------------------------------------------
 
 def do_detach(all_clients: bool = False) -> None:
-    """Detach the ccmux tmux session."""
+    """Detach from the workspace."""
     if not tmux_session_exists(OUTER_SESSION):
-        raise DetachError("No active ccmux session.")
+        raise DetachError("No active workspace to detach from.")
     try:
         if all_clients:
             detach_client(session=OUTER_SESSION)
         else:
             clients = list_clients(OUTER_SESSION)
             if not clients:
-                raise DetachError("No clients attached to ccmux session.")
+                raise DetachError("No clients attached to the workspace.")
             detach_client(client_tty=clients[0])
     except subprocess.CalledProcessError as e:
         raise DetachError(f"Detach failed: {e}") from e
 
 
 def do_attach() -> None:
-    """Attach to the ccmux tmux session."""
+    """Attach to the workspace."""
     sessions = state.get_all_sessions()
     if not sessions:
-        raise AttachError("No ccmux session found.", "Create a session with: ccmux new")
+        raise AttachError("No workspace found.", "Create a session with: ccmux new")
 
     if not tmux_session_exists(INNER_SESSION):
-        raise AttachError("Tmux session no longer exists.", "Activate sessions with: ccmux activate")
+        raise AttachError("Workspace is not running.", "Activate sessions with: ccmux activate")
 
     ensure_outer_session()
     notify_sidebars()
@@ -1169,7 +1169,7 @@ def do_session_which() -> None:
 
 
 def do_session_list() -> None:
-    """List all sessions and their tmux session status."""
+    """List all sessions in the workspace."""
     sessions = state.get_all_sessions()
     if not sessions:
         console.print("\n[yellow]No sessions found.[/yellow]")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -136,7 +136,7 @@ class TestInvalidArgumentError:
 class TestNotInCcmuxSessionError:
     def test_message(self):
         e = NotInCcmuxSessionError()
-        assert str(e) == "Not in a ccmux session."
+        assert str(e) == "Not in a workspace session."
         assert e.exit_code == 1
 
 
@@ -150,20 +150,20 @@ class TestActivationError:
 
 class TestDetachError:
     def test_message(self):
-        e = DetachError("No active ccmux session.")
-        assert str(e) == "No active ccmux session."
-        assert e.reason == "No active ccmux session."
+        e = DetachError("No active workspace to detach from.")
+        assert str(e) == "No active workspace to detach from."
+        assert e.reason == "No active workspace to detach from."
         assert e.exit_code == 1
 
 
 class TestAttachError:
     def test_without_hint(self):
-        e = AttachError("No ccmux session found.")
-        assert str(e) == "No ccmux session found."
+        e = AttachError("No workspace found.")
+        assert str(e) == "No workspace found."
         assert e.hint == ""
 
     def test_with_hint(self):
-        e = AttachError("No ccmux session found.", "Create a session with: ccmux new")
+        e = AttachError("No workspace found.", "Create a session with: ccmux new")
         assert e.hint == "Create a session with: ccmux new"
         assert e.exit_code == 1
 
@@ -257,7 +257,7 @@ class TestCliExceptionHandling:
 
     def test_attach_error_with_hint(self):
         code, mock_console = self._run_main_with_exception(
-            AttachError("No ccmux session found.", "Create a session with: ccmux new")
+            AttachError("No workspace found.", "Create a session with: ccmux new")
         )
         assert code == 1
         mock_console.print.assert_any_call("  Create a session with: ccmux new")


### PR DESCRIPTION
## Summary
- Replace internal tmux jargon ("ccmux tmux session", "tmux window") with user-friendly **"workspace"** and **"session"** terminology across all user-facing help text, console messages, and error messages
- Remove the `debug` subcommand and its `do_debug_sidebar()` function from `session_layout.py`
- Update `test_exceptions.py` assertions to match the new error message strings

## Test plan
- [x] `pytest` — all 184 tests pass
- [x] `ccmux --help` — verify new help text, `debug` command is gone
- [x] `ccmux kill --help` — shows "Deactivate all sessions and shut down the workspace."
- [x] `ccmux attach --help` — shows "Attach to the workspace."

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)