### PR TITLE
feat: Add support for bare repository topologies

### DIFF
--- a/ccmux/config.py
+++ b/ccmux/config.py
@@ -22,24 +22,34 @@ class CommandEvent:
     returncode: int = 0
 
 
-def load_repo_config(repo_root: Path) -> Optional[dict]:
-    """Load ccmux.toml from a repository root.
+def load_repo_config(repo_root: Path, session_path: Optional[Path] = None) -> Optional[dict]:
+    """Load ccmux.toml, checking session_path first then repo root.
+
+    For bare repo topologies the config may live in a worktree rather than
+    (or in addition to) the project root.  When *session_path* differs from
+    *repo_root*, we check the session directory first so worktree-specific
+    configs take precedence.
 
     Args:
-        repo_root: Path to the git repository root
+        repo_root: Path to the git repository / project root
+        session_path: Optional session working directory to check first
 
     Returns:
         Parsed config dict, or None if no config file exists
     """
-    config_path = repo_root / "ccmux.toml"
-    if not config_path.exists():
-        return None
+    search_paths: list[Path] = []
+    if session_path is not None and session_path != repo_root:
+        search_paths.append(session_path / "ccmux.toml")
+    search_paths.append(repo_root / "ccmux.toml")
 
-    try:
-        with open(config_path, "rb") as f:
-            return tomllib.load(f)
-    except Exception:
-        return None
+    for config_path in search_paths:
+        if config_path.exists():
+            try:
+                with open(config_path, "rb") as f:
+                    return tomllib.load(f)
+            except Exception:
+                continue
+    return None
 
 
 def _warn_deprecated_key(section: str, old_key: str, new_key: str) -> None:
@@ -63,13 +73,13 @@ def _resolve_launch(value) -> str:
     return value
 
 
-def get_agent_launch(repo_root: Path) -> str:
+def get_agent_launch(repo_root: Path, session_path: Optional[Path] = None) -> str:
     """Return the agent launch command from ccmux.toml, or 'claude' if not configured.
 
     Reads [agent].launch first. Falls back to deprecated [agent].command with a warning.
     The value can be a string or a list of strings (joined with &&).
     """
-    config = load_repo_config(repo_root)
+    config = load_repo_config(repo_root, session_path)
     if config is None:
         return "claude"
     agent = config.get("agent", {})
@@ -81,13 +91,13 @@ def get_agent_launch(repo_root: Path) -> str:
     return "claude"
 
 
-def get_bash_launch(repo_root: Path) -> str:
+def get_bash_launch(repo_root: Path, session_path: Optional[Path] = None) -> str:
     """Return the bash shell command from ccmux.toml, or '$SHELL' if not configured.
 
     Reads [bash].launch first. Falls back to deprecated [bash].command with a warning.
     The value can be a string or a list of strings (joined with &&).
     """
-    config = load_repo_config(repo_root)
+    config = load_repo_config(repo_root, session_path)
     if config is None:
         return "$SHELL"
     bash = config.get("bash", {})
@@ -97,6 +107,22 @@ def get_bash_launch(repo_root: Path) -> str:
         _warn_deprecated_key("bash", "command", "launch")
         return _resolve_launch(bash["command"])
     return "$SHELL"
+
+
+def get_worktrees_dir(repo_root: Path, session_path: Optional[Path] = None) -> Path:
+    """Return the worktree directory relative path from ccmux.toml, or the default.
+
+    Reads [worktree].dir.  The value is a path relative to repo_root where
+    new ccmux worktrees are created.  Defaults to ``.ccmux/worktrees``.
+    """
+    config = load_repo_config(repo_root, session_path)
+    if config is not None:
+        raw = config.get("worktree", {}).get("dir")
+        if raw:
+            return Path(raw)
+    # Import here to avoid circular dependency at module level
+    from ccmux.naming import WORKTREES_DIR_NAME
+    return WORKTREES_DIR_NAME
 
 
 def _execute_commands(
@@ -162,7 +188,7 @@ def run_post_create_commands(
     Yields:
         CommandEvent objects describing execution progress
     """
-    config = load_repo_config(repo_root)
+    config = load_repo_config(repo_root, session_path)
     if config is None:
         return
 
@@ -192,7 +218,7 @@ def run_session_post_create_commands(
     Yields:
         CommandEvent objects describing execution progress
     """
-    config = load_repo_config(repo_root)
+    config = load_repo_config(repo_root, session_path)
     if config is None:
         return
 
@@ -223,7 +249,7 @@ def run_repo_init_commands(
     Yields:
         CommandEvent objects describing execution progress
     """
-    config = load_repo_config(repo_root)
+    config = load_repo_config(repo_root, session_path)
     if config is None:
         return
 

--- a/ccmux/git_ops.py
+++ b/ccmux/git_ops.py
@@ -34,23 +34,73 @@ def get_repo_root() -> Optional[Path]:
         if git_common_dir.name == ".git":
             return git_common_dir.parent
 
-        # Submodule: --git-common-dir points inside .git/modules/,
-        # not to a .git directory we can derive the working tree from.
-        # Use `git worktree list` to find the main worktree root — the
-        # first entry is always the main worktree, even when called from
-        # inside a linked worktree of the submodule.
+        # Not a simple .git directory — could be a bare repo topology
+        # or a submodule.  Parse ``git worktree list`` to distinguish.
         result = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
             capture_output=True,
             text=True,
             check=True,
         )
+
+        # Parse the first worktree stanza to detect bare repos.
+        first_worktree_path = None
+        is_bare = False
         for line in result.stdout.splitlines():
-            if line.startswith("worktree "):
-                return Path(line[9:])
-        return None
+            if line.startswith("worktree ") and first_worktree_path is None:
+                first_worktree_path = Path(line[9:])
+            elif line == "bare":
+                is_bare = True
+                break
+            elif line == "":
+                break  # end of first stanza
+
+        if first_worktree_path is None:
+            return None
+
+        if is_bare:
+            # Bare repo topology: the project root is the parent of the
+            # bare git directory, where the .git redirect file lives.
+            project_root = git_common_dir.parent
+            if (project_root / ".git").exists():
+                return project_root
+
+        # Submodule or other: first worktree entry is the main worktree.
+        return first_worktree_path
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
+
+
+def get_worktree_root(path: Path) -> Optional[Path]:
+    """Return the git worktree root for *path*, or None if not in a worktree.
+
+    Uses ``git rev-parse --show-toplevel`` which succeeds inside a worktree
+    but fails at a bare repo root or outside any repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def is_bare_repo(repo_path: Path) -> bool:
+    """Check if the repository at repo_path is a bare repo topology."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "--is-bare-repository"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip() == "true"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
 
 
 def get_default_branch() -> Optional[str]:
@@ -127,12 +177,12 @@ def branch_exists(branch_name: str) -> bool:
         return False
 
 
-def get_all_worktrees(repo_root: Path) -> list[dict[str, str]]:
+def get_all_worktrees(repo_root: Path, worktrees_dir_override: Optional[Path] = None) -> list[dict[str, str]]:
     """Get all worktrees in the ccmux worktrees directory.
 
     Returns a list of dicts with keys: name, path, branch
     """
-    worktrees_dir = repo_root / WORKTREES_DIR_NAME
+    worktrees_dir = repo_root / (worktrees_dir_override or WORKTREES_DIR_NAME)
     if not worktrees_dir.exists():
         return []
 

--- a/ccmux/session_ops.py
+++ b/ccmux/session_ops.py
@@ -19,6 +19,7 @@ from ccmux import __version__, state
 from ccmux.config import (
     get_agent_launch,
     get_bash_launch,
+    get_worktrees_dir,
     run_post_create_commands,
     run_repo_init_commands,
     run_session_post_create_commands,
@@ -45,6 +46,8 @@ from ccmux.git_ops import (
     get_default_branch,
     get_most_recently_used_branch,
     get_repo_root,
+    get_worktree_root,
+    is_bare_repo,
     move_worktree,
     remove_worktree,
     worktree_exists,
@@ -282,13 +285,17 @@ def _validate_repo_context(path: Optional[str] = None) -> tuple[Path, str, Path]
     """Validate git repo and return (repo_root, default_branch, working_dir).
 
     When *path* is given, *working_dir* is the resolved path (which may be a
-    subdirectory inside the repo).  Otherwise *working_dir* equals *repo_root*.
+    subdirectory inside the repo).  Otherwise *working_dir* equals *repo_root*
+    — except for bare repo topologies where the original cwd's worktree root
+    is preserved so the caller can reuse an existing worktree.
     """
     if path is not None:
         resolved = Path(path).resolve()
         if not resolved.is_dir():
             raise InvalidArgumentError(f"Path is not a directory: {resolved}")
         os.chdir(resolved)
+
+    original_cwd = Path.cwd().resolve()
     repo_root = get_repo_root()
     if repo_root is None:
         raise NotInGitRepoError(path or "")
@@ -302,13 +309,35 @@ def _validate_repo_context(path: Optional[str] = None) -> tuple[Path, str, Path]
     if default_branch is None:
         raise DefaultBranchError()
 
-    working_dir = resolved if path is not None else repo_root
+    if path is not None:
+        working_dir = resolved
+    elif is_bare_repo(repo_root) and original_cwd != repo_root:
+        # Inside a bare repo topology — preserve the worktree root so the
+        # caller can reuse the existing worktree instead of creating one.
+        working_dir = get_worktree_root(original_cwd) or repo_root
+    else:
+        working_dir = repo_root
     return repo_root, default_branch, working_dir
 
 
-def _resolve_session_type(repo_root: Path, worktree: bool, yes: bool) -> bool:
+def _resolve_session_type(repo_root: Path, worktree: bool, yes: bool,
+                          working_dir: Optional[Path] = None) -> bool:
     """Decide whether to create as worktree. Returns create_as_worktree flag."""
     if worktree:
+        return True
+    if is_bare_repo(repo_root):
+        if working_dir is not None and working_dir != repo_root:
+            # Inside an existing worktree — use it directly.
+            # Check for duplicate session at this worktree path.
+            for sess in state.get_all_sessions():
+                if sess.session_path == str(working_dir):
+                    console.print(f"[yellow]Warning:[/yellow] This worktree already has a session: '{sess.name}'")
+                    if yes or Confirm.ask("Create a new worktree instead?", default=True):
+                        return True
+                    raise UserAbortedError("Worktree already in use.")
+            return False
+        # At bare repo root — create a worktree.
+        console.print("[yellow]Bare repository detected — creating worktree session.[/yellow]")
         return True
     existing_main = state.find_main_repo_session(str(repo_root))
     if existing_main:
@@ -319,25 +348,27 @@ def _resolve_session_type(repo_root: Path, worktree: bool, yes: bool) -> bool:
     return False
 
 
-def session_name_exists(name: str, repo_root: Path) -> bool:
+def session_name_exists(name: str, repo_root: Path, worktrees_dir: Optional[Path] = None) -> bool:
     """Check if a session name is already in use (session state or worktree on disk)."""
     if state.get_session(name):
         return True
-    test_path = repo_root / WORKTREES_DIR_NAME / name
+    wt_dir = worktrees_dir if worktrees_dir is not None else WORKTREES_DIR_NAME
+    test_path = repo_root / wt_dir / name
     return worktree_exists(test_path, repo_root)
 
 
-def _generate_session_name(repo_root: Path, create_as_worktree: bool, name: Optional[str]) -> str:
+def _generate_session_name(repo_root: Path, create_as_worktree: bool, name: Optional[str],
+                           worktrees_dir: Optional[Path] = None) -> str:
     """Generate or sanitize session name."""
     if name is not None:
         sanitized = sanitize_name(name)
-        if session_name_exists(sanitized, repo_root):
+        if session_name_exists(sanitized, repo_root, worktrees_dir):
             raise SessionExistsError(sanitized)
         return sanitized
 
     for _ in range(20):
         candidate = sanitize_name(generate_animal_name())
-        if not session_name_exists(candidate, repo_root):
+        if not session_name_exists(candidate, repo_root, worktrees_dir):
             return candidate
 
     base = sanitize_name(generate_animal_name())
@@ -447,8 +478,9 @@ def _reactivate_single_orphan(sess) -> None:
     repo_root = Path(sess.repo_path)
     sess_type = sess.session_type + " repo" if not sess.is_worktree else "worktree"
 
-    agent_launch = get_agent_launch(repo_root)
-    shell_launch = get_bash_launch(repo_root)
+    session_path = Path(path)
+    agent_launch = get_agent_launch(repo_root, session_path)
+    shell_launch = get_bash_launch(repo_root, session_path)
     orphan_session_id = sess.claude_session_id or str(uuid.uuid4())
     cmd = build_agent_command(name, orphan_session_id, repo_root=str(repo_root), session_path=path, agent_launch=agent_launch, resume=bool(sess.claude_session_id))
 
@@ -464,12 +496,13 @@ def _reactivate_single_orphan(sess) -> None:
 def do_session_new(name: Optional[str] = None, worktree: bool = False, yes: bool = False, path: Optional[str] = None) -> None:
     """Create a new Claude Code session."""
     repo_root, default_branch, working_dir = _validate_repo_context(path)
-    create_as_worktree = _resolve_session_type(repo_root, worktree, yes)
-    name = _generate_session_name(repo_root, create_as_worktree, name)
+    create_as_worktree = _resolve_session_type(repo_root, worktree, yes, working_dir)
+    worktrees_dir = get_worktrees_dir(repo_root, working_dir)
+    name = _generate_session_name(repo_root, create_as_worktree, name, worktrees_dir)
 
     if create_as_worktree:
-        session_path = repo_root / WORKTREES_DIR_NAME / name
-        (repo_root / WORKTREES_DIR_NAME).mkdir(parents=True, exist_ok=True)
+        session_path = repo_root / worktrees_dir / name
+        (repo_root / worktrees_dir).mkdir(parents=True, exist_ok=True)
     else:
         session_path = working_dir
 
@@ -479,6 +512,10 @@ def do_session_new(name: Optional[str] = None, worktree: bool = False, yes: bool
 
     if create_as_worktree:
         _setup_worktree(repo_root, session_path, default_branch, name)
+    elif session_path != repo_root:
+        # Reusing an existing worktree (bare repo topology) — still run
+        # [worktree].post_create hooks since this is a new session.
+        _run_post_create_with_display(repo_root, session_path, name)
 
     if is_first_for_repo:
         _run_repo_init_with_display(repo_root, session_path, name)
@@ -487,8 +524,8 @@ def do_session_new(name: Optional[str] = None, worktree: bool = False, yes: bool
 
     is_first = not tmux_session_exists(INNER_SESSION)
 
-    agent_launch = get_agent_launch(repo_root)
-    shell_launch = get_bash_launch(repo_root)
+    agent_launch = get_agent_launch(repo_root, session_path)
+    shell_launch = get_bash_launch(repo_root, session_path)
     session_type = "worktree" if create_as_worktree else "main repo"
     claude_session_id = str(uuid.uuid4())
     launch_cmd = build_agent_command(name, claude_session_id, repo_root=str(repo_root), session_path=str(session_path), agent_launch=agent_launch)
@@ -645,8 +682,8 @@ def _rename_active_worktree(old_name: str, new_name: str, session_data) -> None:
         raise SessionExistsError(new_name)
     state.update_session(new_name, session_path=str(new_path))
 
-    agent_launch = get_agent_launch(repo_path)
-    shell_launch = get_bash_launch(repo_path)
+    agent_launch = get_agent_launch(repo_path, new_path)
+    shell_launch = get_bash_launch(repo_path, new_path)
     new_cc_window_id = _create_renamed_window(new_name, new_path, session_data, migrated, agent_launch, str(repo_path))
 
     new_bash_window_id = create_bash_window(new_name, str(new_path), shell_launch, str(repo_path))
@@ -1114,8 +1151,9 @@ def _activate_all(yes: bool = False) -> None:
             state.clear_tmux_window_ids(sess.name)
         is_first = not inner_exists and i == 0
         repo_root = Path(sess.repo_path)
-        agent_launch = get_agent_launch(repo_root)
-        shell_launch = get_bash_launch(repo_root)
+        sess_path = Path(sess.session_path)
+        agent_launch = get_agent_launch(repo_root, sess_path)
+        shell_launch = get_bash_launch(repo_root, sess_path)
         claude_session_id = sess.claude_session_id or str(uuid.uuid4())
         launch_cmd = build_agent_command(sess.name, claude_session_id, repo_root=str(repo_root), session_path=sess.session_path, agent_launch=agent_launch, resume=bool(sess.claude_session_id))
 
@@ -1159,8 +1197,9 @@ def _activate_single(name: str, yes: bool = False) -> None:
 
     is_first = not tmux_session_exists(INNER_SESSION)
     repo_root = Path(session.repo_path)
-    agent_launch = get_agent_launch(repo_root)
-    shell_launch = get_bash_launch(repo_root)
+    sess_path = Path(session.session_path)
+    agent_launch = get_agent_launch(repo_root, sess_path)
+    shell_launch = get_bash_launch(repo_root, sess_path)
     claude_session_id = session.claude_session_id or str(uuid.uuid4())
     launch_cmd = build_agent_command(name, claude_session_id, repo_root=str(repo_root), session_path=session.session_path, agent_launch=agent_launch, resume=bool(session.claude_session_id))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,8 @@ from ccmux.config import (
     CommandEvent,
     get_agent_launch,
     get_bash_launch,
+    get_worktrees_dir,
+    load_repo_config,
     run_post_create_commands,
     run_repo_init_commands,
     run_session_post_create_commands,
@@ -80,6 +82,94 @@ class TestGetBashLaunch:
     def test_list_of_commands_joined(self, tmp_path):
         _write_config(tmp_path, '[bash]\nlaunch = ["export FOO=bar", "exec bash"]\n')
         assert get_bash_launch(tmp_path) == "export FOO=bar && exec bash"
+
+
+# ---------------------------------------------------------------------------
+# Config search path tests (worktree-first fallback for bare repos)
+# ---------------------------------------------------------------------------
+
+class TestConfigSearchPath:
+    """Tests for load_repo_config session_path-first search."""
+
+    def test_session_path_takes_precedence(self, tmp_path):
+        """Config in session_path is preferred over repo_root."""
+        repo_root = tmp_path / "repo"
+        session = tmp_path / "session"
+        repo_root.mkdir()
+        session.mkdir()
+        (repo_root / "ccmux.toml").write_text('[agent]\nlaunch = "from-repo"\n')
+        (session / "ccmux.toml").write_text('[agent]\nlaunch = "from-session"\n')
+
+        config = load_repo_config(repo_root, session_path=session)
+        assert config["agent"]["launch"] == "from-session"
+
+    def test_falls_back_to_repo_root(self, tmp_path):
+        """When session_path has no config, falls back to repo_root."""
+        repo_root = tmp_path / "repo"
+        session = tmp_path / "session"
+        repo_root.mkdir()
+        session.mkdir()
+        (repo_root / "ccmux.toml").write_text('[agent]\nlaunch = "from-repo"\n')
+
+        config = load_repo_config(repo_root, session_path=session)
+        assert config["agent"]["launch"] == "from-repo"
+
+    def test_no_session_path_uses_repo_root(self, tmp_path):
+        """Without session_path, behaves like before (repo_root only)."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / "ccmux.toml").write_text('[agent]\nlaunch = "from-repo"\n')
+
+        config = load_repo_config(repo_root)
+        assert config["agent"]["launch"] == "from-repo"
+
+    def test_session_path_same_as_repo_root(self, tmp_path):
+        """When session_path == repo_root, no duplicate check."""
+        _write_config(tmp_path, '[agent]\nlaunch = "hello"\n')
+        config = load_repo_config(tmp_path, session_path=tmp_path)
+        assert config["agent"]["launch"] == "hello"
+
+    def test_none_when_neither_has_config(self, tmp_path):
+        """Returns None when no config exists in either path."""
+        repo_root = tmp_path / "repo"
+        session = tmp_path / "session"
+        repo_root.mkdir()
+        session.mkdir()
+        assert load_repo_config(repo_root, session_path=session) is None
+
+    def test_get_worktrees_dir_default(self, tmp_path):
+        """Returns default .ccmux/worktrees when no config."""
+        assert str(get_worktrees_dir(tmp_path)) == ".ccmux/worktrees"
+
+    def test_get_worktrees_dir_from_config(self, tmp_path):
+        """Returns configured [worktree].dir value."""
+        _write_config(tmp_path, '[worktree]\ndir = "."\n')
+        assert str(get_worktrees_dir(tmp_path)) == "."
+
+    def test_get_worktrees_dir_custom_path(self, tmp_path):
+        """Returns a custom relative path from config."""
+        _write_config(tmp_path, '[worktree]\ndir = "my-worktrees"\n')
+        assert str(get_worktrees_dir(tmp_path)) == "my-worktrees"
+
+    def test_get_agent_launch_with_session_path(self, tmp_path):
+        """get_agent_launch forwards session_path to load_repo_config."""
+        repo_root = tmp_path / "repo"
+        session = tmp_path / "session"
+        repo_root.mkdir()
+        session.mkdir()
+        (session / "ccmux.toml").write_text('[agent]\nlaunch = "from-session"\n')
+
+        assert get_agent_launch(repo_root, session) == "from-session"
+
+    def test_get_bash_launch_with_session_path(self, tmp_path):
+        """get_bash_launch forwards session_path to load_repo_config."""
+        repo_root = tmp_path / "repo"
+        session = tmp_path / "session"
+        repo_root.mkdir()
+        session.mkdir()
+        (session / "ccmux.toml").write_text('[bash]\nlaunch = "from-session"\n')
+
+        assert get_bash_launch(repo_root, session) == "from-session"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -10,6 +10,8 @@ from ccmux.git_ops import (
     get_default_branch,
     get_most_recently_used_branch,
     get_repo_root,
+    get_worktree_root,
+    is_bare_repo,
 )
 
 
@@ -149,6 +151,103 @@ class TestGetRepoRoot:
         """Returns None when git command fails."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "git")
         assert get_repo_root() is None
+
+    @patch("ccmux.git_ops.Path.exists", return_value=True)
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_bare_repo_returns_project_root(self, mock_run, mock_exists):
+        """Bare repo topology: returns the project root, not the .bare dir.
+
+        When --git-common-dir returns a path like /project/.bare (not .git),
+        and ``git worktree list`` marks the first entry as ``bare``, the
+        project root is the parent of the bare git directory.
+        """
+        mock_run.side_effect = [
+            _make_completed_process("/home/user/project/.bare\n"),
+            _make_completed_process(
+                "worktree /home/user/project/.bare\nbare\n\n"
+                "worktree /home/user/project/main\nHEAD abc123\n"
+                "branch refs/heads/main\n\n"
+            ),
+        ]
+        assert get_repo_root() == Path("/home/user/project")
+        assert mock_run.call_count == 2
+
+    @patch("ccmux.git_ops.Path.exists", return_value=True)
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_bare_repo_from_worktree(self, mock_run, mock_exists):
+        """Bare repo from inside a worktree still returns the project root.
+
+        Git resolves through the worktree to the shared bare repo, so
+        --git-common-dir returns the same .bare path regardless of cwd.
+        """
+        mock_run.side_effect = [
+            _make_completed_process("/home/user/project/.bare\n"),
+            _make_completed_process(
+                "worktree /home/user/project/.bare\nbare\n\n"
+                "worktree /home/user/project/main\nHEAD abc123\n"
+                "branch refs/heads/main\n\n"
+            ),
+        ]
+        assert get_repo_root() == Path("/home/user/project")
+
+    @patch("ccmux.git_ops.Path.exists", return_value=False)
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_bare_repo_without_git_redirect_falls_back(self, mock_run, mock_exists):
+        """Bare repo without .git at parent falls back to first worktree path.
+
+        Standalone bare repos (no .git redirect file) should not crash.
+        """
+        mock_run.side_effect = [
+            _make_completed_process("/some/bare-repo.git\n"),
+            _make_completed_process(
+                "worktree /some/bare-repo.git\nbare\n\n"
+            ),
+        ]
+        assert get_repo_root() == Path("/some/bare-repo.git")
+
+
+class TestGetWorktreeRoot:
+    """Tests for get_worktree_root()."""
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_worktree_root(self, mock_run):
+        """Returns the worktree root when inside a worktree."""
+        mock_run.return_value = _make_completed_process("/home/user/project/main\n")
+        assert get_worktree_root(Path("/home/user/project/main/src")) == Path("/home/user/project/main")
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_none_at_bare_root(self, mock_run):
+        """Returns None when at a bare repo root (not a worktree)."""
+        mock_run.side_effect = subprocess.CalledProcessError(128, "git")
+        assert get_worktree_root(Path("/home/user/project")) is None
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_none_outside_repo(self, mock_run):
+        """Returns None when outside any git repo."""
+        mock_run.side_effect = subprocess.CalledProcessError(128, "git")
+        assert get_worktree_root(Path("/tmp")) is None
+
+
+class TestIsBareRepo:
+    """Tests for is_bare_repo()."""
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_true_for_bare_repo(self, mock_run):
+        """Returns True when git reports bare repository."""
+        mock_run.return_value = _make_completed_process("true\n")
+        assert is_bare_repo(Path("/home/user/project")) is True
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_false_for_normal_repo(self, mock_run):
+        """Returns False for a normal (non-bare) repository."""
+        mock_run.return_value = _make_completed_process("false\n")
+        assert is_bare_repo(Path("/home/user/project")) is False
+
+    @patch("ccmux.git_ops.subprocess.run")
+    def test_returns_false_on_failure(self, mock_run):
+        """Returns False when git command fails."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+        assert is_bare_repo(Path("/home/user/project")) is False
 
 
 class TestCreateWorktree:


### PR DESCRIPTION
## Summary
- Fix get_repo_root() for bare repo topologies (.git redirect + .bare/ dir)
- Reuse existing worktrees when running ccmux new from inside one
- Auto-create worktrees when running from bare repo root
- Add [worktree].dir config to control worktree placement
- Config lookup checks session path first, then repo root
- post_create hooks fire when adopting existing worktrees

## Test plan
- [x] 63/63 tests pass, 20 new tests added
- [ ] Manual test with bare repo topology