### PR TITLE
feat: Add clipboard support for WSL and OSC 52 terminals

### DIFF
--- a/ccmux/ui/tmux/config.py
+++ b/ccmux/ui/tmux/config.py
@@ -22,6 +22,15 @@ def _wait_for_session(session_name: str, timeout: float = 2.0) -> bool:
     return False
 
 
+def _is_wsl() -> bool:
+    """Return True if running under Windows Subsystem for Linux."""
+    try:
+        with open("/proc/version") as f:
+            return "microsoft" in f.read().lower()
+    except OSError:
+        return False
+
+
 def _detect_clipboard_command() -> str | None:
     """Detect available clipboard command, or None if no clipboard tool found."""
     if shutil.which("xclip"):
@@ -30,6 +39,8 @@ def _detect_clipboard_command() -> str | None:
         return "xsel --clipboard --input"
     if shutil.which("wl-copy"):
         return "wl-copy"
+    if _is_wsl() and shutil.which("clip.exe"):
+        return "clip.exe"
     return None
 
 
@@ -41,7 +52,7 @@ def _apply_copy_mode_config(session_name: str) -> None:
     - Mouse drag auto-copies selection (pane-scoped, avoids cross-pane issues)
     - Double-click selects word, triple-click selects line
     - 'y' in copy-mode yanks selection
-    - Pipes to system clipboard when xclip/xsel/wl-copy is available
+    - Pipes to system clipboard when xclip/xsel/wl-copy/clip.exe is available
     """
     clip_cmd = _detect_clipboard_command()
 
@@ -164,7 +175,7 @@ def _terminal_features_contains_rgb() -> bool:
 
 
 def apply_server_global_config() -> bool:
-    """Apply server-global tmux options for true-color support."""
+    """Apply server-global tmux options for true-color support and clipboard."""
     try:
         subprocess.run(
             ["tmux", "set-option", "-g", "default-terminal", "tmux-256color"],
@@ -176,6 +187,12 @@ def apply_server_global_config() -> bool:
                  ",tmux-256color:RGB"],
                 check=True, capture_output=True,
             )
+        # Emit OSC 52 on copy so the host terminal (e.g. Windows Terminal,
+        # iTerm2) can populate the OS clipboard even without xclip/clip.exe.
+        subprocess.run(
+            ["tmux", "set-option", "-g", "set-clipboard", "on"],
+            check=True, capture_output=True,
+        )
         return True
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
## Summary
- Detect WSL and fall back to `clip.exe` when no native Linux clipboard tool is found (`_detect_clipboard_command`)
- Enable `set-clipboard on` globally in `apply_server_global_config()` so tmux emits OSC 52 — modern terminals (Windows Terminal, iTerm2, Kitty) then populate the host OS clipboard
- Single-file change in `ccmux/ui/tmux/config.py`

Fixes #64

## Test plan
- [ ] **WSL + Windows Terminal (no Linux clipboard tools):** Launch ccmux, mouse-drag select in a pane, paste into a Windows app (Notepad/browser) — text appears.
- [ ] **Native Linux with xclip/xsel/wl-copy:** Same gesture — existing native path still copies to the OS clipboard (no regression).
- [ ] **WSL with xclip installed (WSLg):** `_detect_clipboard_command()` returns the xclip command, not `clip.exe`.
- [ ] **Sanity:** `tmux show-options -g set-clipboard` prints `set-clipboard on` inside a ccmux session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)